### PR TITLE
[A2Y-265] fix add item

### DIFF
--- a/feature/common/src/main/java/com/yapp/itemfinder/feature/common/datalist/adapter/viewholder/AddItemMemoViewHolder.kt
+++ b/feature/common/src/main/java/com/yapp/itemfinder/feature/common/datalist/adapter/viewholder/AddItemMemoViewHolder.kt
@@ -1,8 +1,5 @@
 package com.yapp.itemfinder.feature.common.datalist.adapter.viewholder
 
-import android.text.InputType
-import android.view.KeyEvent
-import android.view.inputmethod.EditorInfo
 import com.yapp.itemfinder.domain.model.AddItemMemo
 import com.yapp.itemfinder.domain.model.ScreenMode
 import com.yapp.itemfinder.feature.common.databinding.AddItemMemoBinding
@@ -23,21 +20,5 @@ class AddItemMemoViewHolder(
         }
     }
 
-    override fun bindViews(data: AddItemMemo) {
-        binding.memoEditText.imeOptions = EditorInfo.IME_ACTION_DONE
-        binding.memoEditText.setRawInputType(InputType.TYPE_CLASS_TEXT)
-        binding.memoEditText.setOnEditorActionListener { textView, actionId, keyEvent ->
-            if (actionId == EditorInfo.IME_ACTION_DONE) {
-                data.setItemMemo(textView.text.toString())
-            }
-            false
-        }
-        binding.memoEditText.setOnKeyListener { view, keyCode, keyEvent ->
-            if (keyEvent.action == KeyEvent.ACTION_DOWN && keyCode == KeyEvent.KEYCODE_ENTER) {
-                data.setItemMemo(binding.memoEditText.text.toString())
-            }
-            false
-        }
-        return
-    }
+    override fun bindViews(data: AddItemMemo) = Unit
 }

--- a/feature/common/src/main/java/com/yapp/itemfinder/feature/common/datalist/adapter/viewholder/AddItemNameViewHolder.kt
+++ b/feature/common/src/main/java/com/yapp/itemfinder/feature/common/datalist/adapter/viewholder/AddItemNameViewHolder.kt
@@ -1,8 +1,5 @@
 package com.yapp.itemfinder.feature.common.datalist.adapter.viewholder
 
-import android.view.KeyEvent
-import android.view.KeyEvent.KEYCODE_ENTER
-import android.view.inputmethod.EditorInfo
 import com.yapp.itemfinder.domain.model.AddItemName
 import com.yapp.itemfinder.domain.model.ScreenMode
 import com.yapp.itemfinder.feature.common.databinding.AddItemNameBinding
@@ -23,20 +20,6 @@ class AddItemNameViewHolder(
         }
     }
 
-    override fun bindViews(data: AddItemName) {
-        binding.itemNameEditText.setOnEditorActionListener { textView, actionId, keyEvent ->
-            if (actionId == EditorInfo.IME_ACTION_DONE) {
-                data.setItemName(textView.text.toString())
-            }
-            false
-        }
-        binding.itemNameEditText.setOnKeyListener { view, keyCode, keyEvent ->
-            if (keyEvent.action == KeyEvent.ACTION_DOWN && keyCode == KEYCODE_ENTER) {
-                data.setItemName(binding.itemNameEditText.text.toString())
-            }
-            false
-        }
-        return
-    }
+    override fun bindViews(data: AddItemName) = Unit
 
 }

--- a/feature/common/src/main/java/com/yapp/itemfinder/feature/common/datalist/adapter/viewholder/AddLockerNameInputViewHolder.kt
+++ b/feature/common/src/main/java/com/yapp/itemfinder/feature/common/datalist/adapter/viewholder/AddLockerNameInputViewHolder.kt
@@ -1,6 +1,5 @@
 package com.yapp.itemfinder.feature.common.datalist.adapter.viewholder
 
-import android.view.inputmethod.EditorInfo
 import com.yapp.itemfinder.domain.model.AddLockerNameInput
 import com.yapp.itemfinder.feature.common.databinding.AddLockerNameInputBinding
 import com.yapp.itemfinder.feature.common.datalist.adapter.DataViewHolder
@@ -19,13 +18,5 @@ class AddLockerNameInputViewHolder(
         }
     }
 
-    override fun bindViews(data: AddLockerNameInput) {
-        binding.lockerNameEditText.setOnEditorActionListener { textView, actionId, keyEvent ->
-            if (actionId == EditorInfo.IME_ACTION_DONE) {
-                data.enterName(textView.text.toString())
-                return@setOnEditorActionListener true
-            }
-            false
-        }
-    }
+    override fun bindViews(data: AddLockerNameInput) = Unit
 }

--- a/feature/space/src/main/java/com/yapp/itemfinder/space/additem/AddItemViewModel.kt
+++ b/feature/space/src/main/java/com/yapp/itemfinder/space/additem/AddItemViewModel.kt
@@ -167,8 +167,7 @@ class AddItemViewModel @Inject constructor(
                 (newDataList[nameIndex] as AddItemName).copy(name = newName)
             setState(
                 state.copy(
-                    dataList = newDataList,
-                    isRefreshNeed = false
+                    dataList = newDataList
                 )
             )
         }

--- a/feature/space/src/main/java/com/yapp/itemfinder/space/selectspace/SelectSpaceActivity.kt
+++ b/feature/space/src/main/java/com/yapp/itemfinder/space/selectspace/SelectSpaceActivity.kt
@@ -2,7 +2,6 @@ package com.yapp.itemfinder.space.selectspace
 
 import android.content.Context
 import android.content.Intent
-import android.view.KeyEvent
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle


### PR DESCRIPTION
[A2Y-265](https://and2y21.atlassian.net/browse/A2Y-265)
### Summary
- 이름이나 메모 입력을 완료하면 다른 UI가 동작하지 않는 문제를 해결했습니다.
- 물건 추가 시, 보관함 추가 시 입력된 값을 다시 set하기 때문에 키보드 이벤트 관련 코드는 제거했습니다.


### References

- JIRA Issue:
- Design Spec:
- Discord Thread:

[A2Y-265]: https://and2y21.atlassian.net/browse/A2Y-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ